### PR TITLE
Extract reusable widget5 UI components into ocean-widget-platform

### DIFF
--- a/plugin/platform/dist/ocean-widget-platform.cjs
+++ b/plugin/platform/dist/ocean-widget-platform.cjs
@@ -1,13 +1,64 @@
 const React = require('react');
 let spinnerStylesInjected = false;
+let compassRoseStylesInjected = false;
 
 function ensureSpinnerStyles() {
-  if (spinnerStylesInjected || typeof document === 'undefined') return;
+  if (typeof document === 'undefined') return;
+  const existingTag = document.head && document.head.querySelector('style[data-owp-spinner="true"]');
+  if (existingTag) {
+    spinnerStylesInjected = true;
+    return;
+  }
+  if (spinnerStylesInjected) return;
   const styleTag = document.createElement('style');
   styleTag.setAttribute('data-owp-spinner', 'true');
   styleTag.textContent = '@keyframes owp-spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }';
   document.head.appendChild(styleTag);
   spinnerStylesInjected = true;
+}
+
+function ensureCompassRoseStyles() {
+  if (typeof document === 'undefined') return;
+  const existingTag = document.head && document.head.querySelector('style[data-owp-compass-rose="true"]');
+  if (existingTag) {
+    compassRoseStylesInjected = true;
+    return;
+  }
+  if (compassRoseStylesInjected) return;
+  const styleTag = document.createElement('style');
+  styleTag.setAttribute('data-owp-compass-rose', 'true');
+  styleTag.textContent = `
+    .owp-compass-rose-container {
+      animation: owp-compass-fade-in 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+      user-select: none;
+      -webkit-user-select: none;
+      -ms-user-select: none;
+      pointer-events: none;
+      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    .owp-compass-rose-svg {
+      transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), filter 0.2s ease-out;
+      backdrop-filter: blur(1px);
+      -webkit-backdrop-filter: blur(1px);
+      pointer-events: none;
+    }
+    .owp-compass-rose-container:hover .owp-compass-rose-svg {
+      filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.4));
+      transform: scale(1.03);
+    }
+    @keyframes owp-compass-fade-in {
+      from { opacity: 0; transform: scale(0.9) translateY(8px); }
+      to { opacity: 0.94; transform: scale(1) translateY(0); }
+    }
+    @media (max-width: 768px) {
+      .owp-compass-rose-container { transform: scale(0.85); transform-origin: bottom left; }
+    }
+    @media (max-width: 480px) {
+      .owp-compass-rose-container { transform: scale(0.75); transform-origin: bottom left; opacity: 0.88; }
+    }
+  `;
+  document.head.appendChild(styleTag);
+  compassRoseStylesInjected = true;
 }
 
 function PlatformPlaceholder({ label = 'Ocean Widget Platform Ready' }) {
@@ -47,6 +98,10 @@ function CompassRose({ position = 'bottom-left', size = 100, mapRotation = 0, re
   const [currentPosition, setCurrentPosition] = React.useState(position);
 
   React.useEffect(() => {
+    ensureCompassRoseStyles();
+  }, []);
+
+  React.useEffect(() => {
     if (!responsive || typeof window === 'undefined') return undefined;
     const handleResize = () => {
       const isMobile = window.innerWidth < 768;
@@ -68,10 +123,10 @@ function CompassRose({ position = 'bottom-left', size = 100, mapRotation = 0, re
 
   return React.createElement(
     'div',
-    { style: { position: 'absolute', zIndex: 1000, pointerEvents: 'none', opacity: 0.94, ...positionStyles[currentPosition], width: `${size}px`, height: `${size}px` } },
+    { className: 'owp-compass-rose-container', style: { position: 'absolute', zIndex: 1000, pointerEvents: 'none', opacity: 0.94, ...positionStyles[currentPosition], width: `${size}px`, height: `${size}px` } },
     React.createElement(
       'svg',
-      { width: size, height: size, viewBox: '0 0 120 120', style: { transform: mapRotation ? `rotate(${-mapRotation}deg)` : 'none', filter: 'drop-shadow(0 6px 12px rgba(0,0,0,0.35))' } },
+      { className: 'owp-compass-rose-svg', width: size, height: size, viewBox: '0 0 120 120', style: { transform: mapRotation ? `rotate(${-mapRotation}deg)` : 'none', filter: 'drop-shadow(0 6px 12px rgba(0,0,0,0.35))' } },
       React.createElement('circle', { cx: '60', cy: '60', r: '55', fill: 'rgba(15,23,42,0.95)', stroke: 'rgba(148,163,184,0.4)', strokeWidth: '1.5' }),
       React.createElement('path', { d: 'M 60,12 L 65,45 L 60,40 L 55,45 Z', fill: '#22d3ee', stroke: '#0e7490', strokeWidth: '1.2' }),
       React.createElement('path', { d: 'M 108,60 L 75,65 L 80,60 L 75,55 Z', fill: '#94a3b8', stroke: '#475569', strokeWidth: '0.8' }),
@@ -90,7 +145,13 @@ function getDefaultLogoSrc() {
   return '/COSPPaC_white_crop2.png';
 }
 
-function ModernHeader({ logoSrc = getDefaultLogoSrc() }) {
+function ModernHeader({
+  logoSrc = getDefaultLogoSrc(),
+  title = 'Cook Islands Wave and Inundation Forecast System',
+  subtitle = 'Marine Forecasting • Pacific Community (SPC) Data',
+  statusText = 'Live',
+  showClock = true
+}) {
   const [currentTime, setCurrentTime] = React.useState(new Date());
   React.useEffect(() => {
     const timer = setInterval(() => setCurrentTime(new Date()), 1000);
@@ -107,11 +168,11 @@ function ModernHeader({ logoSrc = getDefaultLogoSrc() }) {
       React.createElement(
         'div',
         null,
-        React.createElement('h1', { style: { margin: 0, color: '#00d4ff', fontSize: '1.5rem', fontWeight: '700' } }, 'Cook Islands Wave and Inundation Forecast System'),
-        React.createElement('p', { style: { margin: 0, color: 'rgba(255,255,255,0.8)', fontSize: '0.9rem', fontWeight: '300' } }, 'Marine Forecasting • Pacific Community (SPC) Data')
+        React.createElement('h1', { style: { margin: 0, color: '#00d4ff', fontSize: '1.5rem', fontWeight: '700' } }, title),
+        React.createElement('p', { style: { margin: 0, color: 'rgba(255,255,255,0.8)', fontSize: '0.9rem', fontWeight: '300' } }, subtitle)
       )
     ),
-    React.createElement('div', { style: { display: 'flex', alignItems: 'center', gap: '20px', fontSize: '0.8rem', color: 'rgba(255,255,255,0.7)' } }, `Live ${currentTime.toLocaleString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })}`)
+    React.createElement('div', { style: { display: 'flex', alignItems: 'center', gap: '20px', fontSize: '0.8rem', color: 'rgba(255,255,255,0.7)' } }, showClock ? `${statusText} ${currentTime.toLocaleString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })}` : statusText)
   );
 }
 
@@ -122,8 +183,8 @@ function LoadingSpinner({ size = 28, color = '#3b82f6', label = 'Loading...' }) 
 
   return React.createElement(
     'div',
-    { style: { display: 'inline-flex', alignItems: 'center', gap: '10px' } },
-    React.createElement('span', { style: { width: `${size}px`, height: `${size}px`, borderRadius: '50%', border: '3px solid rgba(148,163,184,0.35)', borderTopColor: color, animation: 'owp-spin 0.8s linear infinite', display: 'inline-block' } }),
+    { style: { display: 'inline-flex', alignItems: 'center', gap: '10px' }, role: 'status', 'aria-live': 'polite', 'aria-busy': true },
+    React.createElement('span', { style: { width: `${size}px`, height: `${size}px`, borderRadius: '50%', border: '3px solid rgba(148,163,184,0.35)', borderTopColor: color, animation: 'owp-spin 0.8s linear infinite', display: 'inline-block' }, 'aria-hidden': true }),
     React.createElement('span', null, label)
   );
 }

--- a/plugin/platform/dist/ocean-widget-platform.cjs
+++ b/plugin/platform/dist/ocean-widget-platform.cjs
@@ -1,9 +1,20 @@
 const React = require('react');
+let spinnerStylesInjected = false;
+
+function ensureSpinnerStyles() {
+  if (spinnerStylesInjected || typeof document === 'undefined') return;
+  const styleTag = document.createElement('style');
+  styleTag.setAttribute('data-owp-spinner', 'true');
+  styleTag.textContent = '@keyframes owp-spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }';
+  document.head.appendChild(styleTag);
+  spinnerStylesInjected = true;
+}
+
 function PlatformPlaceholder({ label = 'Ocean Widget Platform Ready' }) {
   return React.createElement('div', { 'data-testid': 'platform-placeholder', style: { display: 'none' } }, label);
 }
 
-function ArrowSVG({ angle, isDarkMode, size = 22, compassDirection = '', ariaLabel }) {
+function ArrowSVGBase({ angle, isDarkMode, size = 22, compassDirection = '', ariaLabel }) {
   const fillColor = isDarkMode ? '#f1f5f9' : '#000';
   const strokeColor = isDarkMode ? '#64748b' : '#666';
 
@@ -24,6 +35,12 @@ function ArrowSVG({ angle, isDarkMode, size = 22, compassDirection = '', ariaLab
       strokeWidth: '1'
     })
   );
+}
+
+const MemoizedArrowSVG = React.memo(ArrowSVGBase);
+
+function ArrowSVG(props) {
+  return React.createElement(MemoizedArrowSVG, props);
 }
 
 function CompassRose({ position = 'bottom-left', size = 100, mapRotation = 0, responsive = true }) {
@@ -66,7 +83,14 @@ function CompassRose({ position = 'bottom-left', size = 100, mapRotation = 0, re
   );
 }
 
-function ModernHeader() {
+function getDefaultLogoSrc() {
+  if (typeof process !== 'undefined' && process.env && typeof process.env.PUBLIC_URL === 'string') {
+    return `${process.env.PUBLIC_URL}/COSPPaC_white_crop2.png`;
+  }
+  return '/COSPPaC_white_crop2.png';
+}
+
+function ModernHeader({ logoSrc = getDefaultLogoSrc() }) {
   const [currentTime, setCurrentTime] = React.useState(new Date());
   React.useEffect(() => {
     const timer = setInterval(() => setCurrentTime(new Date()), 1000);
@@ -79,11 +103,11 @@ function ModernHeader() {
     React.createElement(
       'div',
       { style: { display: 'flex', alignItems: 'center', gap: '15px' } },
-      React.createElement('img', { src: process.env.PUBLIC_URL + '/COSPPaC_white_crop2.png', alt: 'COSPPaC Logo', height: '35', style: { filter: 'brightness(0) saturate(100%) invert(100%)' } }),
+      React.createElement('img', { src: logoSrc, alt: 'COSPPaC Logo', height: '35', style: { filter: 'brightness(0) saturate(100%) invert(100%)' } }),
       React.createElement(
         'div',
         null,
-        React.createElement('h1', { style: { margin: 0, color: '#00d4ff', fontSize: '1.5rem', fontWeight: '700' } }, 'Cook Islands Wave and Innundation Forecast System'),
+        React.createElement('h1', { style: { margin: 0, color: '#00d4ff', fontSize: '1.5rem', fontWeight: '700' } }, 'Cook Islands Wave and Inundation Forecast System'),
         React.createElement('p', { style: { margin: 0, color: 'rgba(255,255,255,0.8)', fontSize: '0.9rem', fontWeight: '300' } }, 'Marine Forecasting • Pacific Community (SPC) Data')
       )
     ),
@@ -92,12 +116,15 @@ function ModernHeader() {
 }
 
 function LoadingSpinner({ size = 28, color = '#3b82f6', label = 'Loading...' }) {
+  React.useEffect(() => {
+    ensureSpinnerStyles();
+  }, []);
+
   return React.createElement(
     'div',
     { style: { display: 'inline-flex', alignItems: 'center', gap: '10px' } },
     React.createElement('span', { style: { width: `${size}px`, height: `${size}px`, borderRadius: '50%', border: '3px solid rgba(148,163,184,0.35)', borderTopColor: color, animation: 'owp-spin 0.8s linear infinite', display: 'inline-block' } }),
-    React.createElement('span', null, label),
-    React.createElement('style', null, '@keyframes owp-spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }')
+    React.createElement('span', null, label)
   );
 }
 
@@ -120,8 +147,17 @@ function PanelContainer({ title, children, footer, className = '', style = {} })
   );
 }
 
-function ProfessionalLegend({ range = '0,4', className = '', style = {} }) {
-  const url = `https://ocean-plotter.spc.int/legend?layer=wave_height&range=${range}&palette=viridis`;
+const DEFAULT_RANGE = '0,4';
+
+function sanitizeRange(range) {
+  const value = typeof range === 'string' ? range : String(range);
+  const rangePattern = /^[+-]?\d+(\.\d+)?,[+-]?\d+(\.\d+)?$/;
+  return rangePattern.test(value) ? value : DEFAULT_RANGE;
+}
+
+function ProfessionalLegend({ range = DEFAULT_RANGE, className = '', style = {} }) {
+  const safeRange = sanitizeRange(range);
+  const url = `https://ocean-plotter.spc.int/legend?layer=wave_height&range=${encodeURIComponent(safeRange)}&palette=viridis`;
   return React.createElement('div', { className, style: { position: 'relative', borderRadius: '6px', overflow: 'hidden', background: '#fff', border: '1px solid #e2e8f0', ...style } },
     React.createElement('img', { src: url, alt: 'Legend for wave height', style: { maxWidth: '100%', height: 'auto' } })
   );

--- a/plugin/platform/dist/ocean-widget-platform.cjs
+++ b/plugin/platform/dist/ocean-widget-platform.cjs
@@ -1,10 +1,130 @@
 const React = require('react');
 function PlatformPlaceholder({ label = 'Ocean Widget Platform Ready' }) {
+  return React.createElement('div', { 'data-testid': 'platform-placeholder', style: { display: 'none' } }, label);
+}
+
+function ArrowSVG({ angle, isDarkMode, size = 22, compassDirection = '', ariaLabel }) {
+  const fillColor = isDarkMode ? '#f1f5f9' : '#000';
+  const strokeColor = isDarkMode ? '#64748b' : '#666';
+
   return React.createElement(
-    'div',
-    { 'data-testid': 'platform-placeholder', style: { display: 'none' } },
-    label
+    'svg',
+    {
+      width: size,
+      height: size,
+      viewBox: `0 0 ${size} ${size}`,
+      style: { display: 'inline-block', transform: `rotate(${angle}deg)`, filter: isDarkMode ? 'invert(1)' : 'none' },
+      role: 'img',
+      'aria-label': ariaLabel || `Direction: ${angle}° ${compassDirection}`
+    },
+    React.createElement('polygon', {
+      points: `${size / 2},2 ${size * 0.73},${size * 0.82} ${size / 2},${size * 0.64} ${size * 0.27},${size * 0.82}`,
+      fill: fillColor,
+      stroke: strokeColor,
+      strokeWidth: '1'
+    })
   );
 }
 
-module.exports = { PlatformPlaceholder };
+function CompassRose({ position = 'bottom-left', size = 100, mapRotation = 0, responsive = true }) {
+  const [currentPosition, setCurrentPosition] = React.useState(position);
+
+  React.useEffect(() => {
+    if (!responsive || typeof window === 'undefined') return undefined;
+    const handleResize = () => {
+      const isMobile = window.innerWidth < 768;
+      setCurrentPosition(isMobile && position === 'top-right' ? 'bottom-left' : position);
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [position, responsive]);
+
+  const positionStyles = {
+    'top-left': { top: '15px', left: '15px' },
+    'top-right': { top: '15px', right: '15px' },
+    'bottom-left': { bottom: '120px', left: '15px' },
+    'bottom-right': { bottom: '80px', right: '15px' },
+    'center-left': { top: '50%', left: '15px', transform: 'translateY(-50%)' },
+    'map-center': { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }
+  };
+
+  return React.createElement(
+    'div',
+    { style: { position: 'absolute', zIndex: 1000, pointerEvents: 'none', opacity: 0.94, ...positionStyles[currentPosition], width: `${size}px`, height: `${size}px` } },
+    React.createElement(
+      'svg',
+      { width: size, height: size, viewBox: '0 0 120 120', style: { transform: mapRotation ? `rotate(${-mapRotation}deg)` : 'none', filter: 'drop-shadow(0 6px 12px rgba(0,0,0,0.35))' } },
+      React.createElement('circle', { cx: '60', cy: '60', r: '55', fill: 'rgba(15,23,42,0.95)', stroke: 'rgba(148,163,184,0.4)', strokeWidth: '1.5' }),
+      React.createElement('path', { d: 'M 60,12 L 65,45 L 60,40 L 55,45 Z', fill: '#22d3ee', stroke: '#0e7490', strokeWidth: '1.2' }),
+      React.createElement('path', { d: 'M 108,60 L 75,65 L 80,60 L 75,55 Z', fill: '#94a3b8', stroke: '#475569', strokeWidth: '0.8' }),
+      React.createElement('path', { d: 'M 60,108 L 55,75 L 60,80 L 65,75 Z', fill: '#94a3b8', stroke: '#475569', strokeWidth: '0.8' }),
+      React.createElement('path', { d: 'M 12,60 L 45,55 L 40,60 L 45,65 Z', fill: '#94a3b8', stroke: '#475569', strokeWidth: '0.8' }),
+      React.createElement('circle', { cx: '60', cy: '60', r: '4', fill: '#0891b2', stroke: '#22d3ee', strokeWidth: '1' }),
+      React.createElement('text', { x: '60', y: '8', textAnchor: 'middle', fontSize: '14', fontWeight: 'bold', fill: '#22d3ee' }, 'N')
+    )
+  );
+}
+
+function ModernHeader() {
+  const [currentTime, setCurrentTime] = React.useState(new Date());
+  React.useEffect(() => {
+    const timer = setInterval(() => setCurrentTime(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return React.createElement(
+    'nav',
+    { style: { background: 'linear-gradient(135deg, #0a2463 0%, #1e3a5f 40%, #2e5266 70%, #3e7b69 100%)', minHeight: '60px', padding: '0 30px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', position: 'relative', zIndex: 1001, boxShadow: '0 2px 20px rgba(0,0,0,0.3)', borderBottom: '1px solid rgba(255,255,255,0.1)' } },
+    React.createElement(
+      'div',
+      { style: { display: 'flex', alignItems: 'center', gap: '15px' } },
+      React.createElement('img', { src: process.env.PUBLIC_URL + '/COSPPaC_white_crop2.png', alt: 'COSPPaC Logo', height: '35', style: { filter: 'brightness(0) saturate(100%) invert(100%)' } }),
+      React.createElement(
+        'div',
+        null,
+        React.createElement('h1', { style: { margin: 0, color: '#00d4ff', fontSize: '1.5rem', fontWeight: '700' } }, 'Cook Islands Wave and Innundation Forecast System'),
+        React.createElement('p', { style: { margin: 0, color: 'rgba(255,255,255,0.8)', fontSize: '0.9rem', fontWeight: '300' } }, 'Marine Forecasting • Pacific Community (SPC) Data')
+      )
+    ),
+    React.createElement('div', { style: { display: 'flex', alignItems: 'center', gap: '20px', fontSize: '0.8rem', color: 'rgba(255,255,255,0.7)' } }, `Live ${currentTime.toLocaleString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })}`)
+  );
+}
+
+function LoadingSpinner({ size = 28, color = '#3b82f6', label = 'Loading...' }) {
+  return React.createElement(
+    'div',
+    { style: { display: 'inline-flex', alignItems: 'center', gap: '10px' } },
+    React.createElement('span', { style: { width: `${size}px`, height: `${size}px`, borderRadius: '50%', border: '3px solid rgba(148,163,184,0.35)', borderTopColor: color, animation: 'owp-spin 0.8s linear infinite', display: 'inline-block' } }),
+    React.createElement('span', null, label),
+    React.createElement('style', null, '@keyframes owp-spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }')
+  );
+}
+
+function LoadingOverlay({ visible = false, label = 'Loading data...' }) {
+  if (!visible) return null;
+  return React.createElement(
+    'div',
+    { style: { position: 'absolute', inset: 0, background: 'rgba(15,23,42,0.35)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 20 } },
+    React.createElement('div', { style: { background: 'rgba(255,255,255,0.9)', padding: '12px 16px', borderRadius: '8px', color: '#0f172a' } }, React.createElement(LoadingSpinner, { label }))
+  );
+}
+
+function PanelContainer({ title, children, footer, className = '', style = {} }) {
+  return React.createElement(
+    'section',
+    { className, style: { display: 'flex', flexDirection: 'column', borderRadius: '12px', overflow: 'hidden', ...style } },
+    title ? React.createElement('header', { style: { padding: '10px 14px', fontWeight: 600 } }, title) : null,
+    React.createElement('div', { style: { flex: 1 } }, children),
+    footer ? React.createElement('footer', { style: { padding: '10px 14px' } }, footer) : null
+  );
+}
+
+function ProfessionalLegend({ range = '0,4', className = '', style = {} }) {
+  const url = `https://ocean-plotter.spc.int/legend?layer=wave_height&range=${range}&palette=viridis`;
+  return React.createElement('div', { className, style: { position: 'relative', borderRadius: '6px', overflow: 'hidden', background: '#fff', border: '1px solid #e2e8f0', ...style } },
+    React.createElement('img', { src: url, alt: 'Legend for wave height', style: { maxWidth: '100%', height: 'auto' } })
+  );
+}
+
+module.exports = { PlatformPlaceholder, ArrowSVG, CompassRose, ModernHeader, LoadingSpinner, LoadingOverlay, PanelContainer, ProfessionalLegend };

--- a/plugin/platform/dist/src/components/PlatformPlaceholder.js
+++ b/plugin/platform/dist/src/components/PlatformPlaceholder.js
@@ -1,9 +1,129 @@
 import React from 'react';
 
 export function PlatformPlaceholder({ label = 'Ocean Widget Platform Ready' }) {
+  return React.createElement('div', { 'data-testid': 'platform-placeholder', style: { display: 'none' } }, label);
+}
+
+export function ArrowSVG({ angle, isDarkMode, size = 22, compassDirection = '', ariaLabel }) {
+  const fillColor = isDarkMode ? '#f1f5f9' : '#000';
+  const strokeColor = isDarkMode ? '#64748b' : '#666';
+
+  return React.createElement(
+    'svg',
+    {
+      width: size,
+      height: size,
+      viewBox: `0 0 ${size} ${size}`,
+      style: { display: 'inline-block', transform: `rotate(${angle}deg)`, filter: isDarkMode ? 'invert(1)' : 'none' },
+      role: 'img',
+      'aria-label': ariaLabel || `Direction: ${angle}° ${compassDirection}`
+    },
+    React.createElement('polygon', {
+      points: `${size / 2},2 ${size * 0.73},${size * 0.82} ${size / 2},${size * 0.64} ${size * 0.27},${size * 0.82}`,
+      fill: fillColor,
+      stroke: strokeColor,
+      strokeWidth: '1'
+    })
+  );
+}
+
+export function CompassRose({ position = 'bottom-left', size = 100, mapRotation = 0, responsive = true }) {
+  const [currentPosition, setCurrentPosition] = React.useState(position);
+
+  React.useEffect(() => {
+    if (!responsive || typeof window === 'undefined') return undefined;
+    const handleResize = () => {
+      const isMobile = window.innerWidth < 768;
+      setCurrentPosition(isMobile && position === 'top-right' ? 'bottom-left' : position);
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [position, responsive]);
+
+  const positionStyles = {
+    'top-left': { top: '15px', left: '15px' },
+    'top-right': { top: '15px', right: '15px' },
+    'bottom-left': { bottom: '120px', left: '15px' },
+    'bottom-right': { bottom: '80px', right: '15px' },
+    'center-left': { top: '50%', left: '15px', transform: 'translateY(-50%)' },
+    'map-center': { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }
+  };
+
   return React.createElement(
     'div',
-    { 'data-testid': 'platform-placeholder', style: { display: 'none' } },
-    label
+    { style: { position: 'absolute', zIndex: 1000, pointerEvents: 'none', opacity: 0.94, ...positionStyles[currentPosition], width: `${size}px`, height: `${size}px` } },
+    React.createElement(
+      'svg',
+      { width: size, height: size, viewBox: '0 0 120 120', style: { transform: mapRotation ? `rotate(${-mapRotation}deg)` : 'none', filter: 'drop-shadow(0 6px 12px rgba(0,0,0,0.35))' } },
+      React.createElement('circle', { cx: '60', cy: '60', r: '55', fill: 'rgba(15,23,42,0.95)', stroke: 'rgba(148,163,184,0.4)', strokeWidth: '1.5' }),
+      React.createElement('path', { d: 'M 60,12 L 65,45 L 60,40 L 55,45 Z', fill: '#22d3ee', stroke: '#0e7490', strokeWidth: '1.2' }),
+      React.createElement('path', { d: 'M 108,60 L 75,65 L 80,60 L 75,55 Z', fill: '#94a3b8', stroke: '#475569', strokeWidth: '0.8' }),
+      React.createElement('path', { d: 'M 60,108 L 55,75 L 60,80 L 65,75 Z', fill: '#94a3b8', stroke: '#475569', strokeWidth: '0.8' }),
+      React.createElement('path', { d: 'M 12,60 L 45,55 L 40,60 L 45,65 Z', fill: '#94a3b8', stroke: '#475569', strokeWidth: '0.8' }),
+      React.createElement('circle', { cx: '60', cy: '60', r: '4', fill: '#0891b2', stroke: '#22d3ee', strokeWidth: '1' }),
+      React.createElement('text', { x: '60', y: '8', textAnchor: 'middle', fontSize: '14', fontWeight: 'bold', fill: '#22d3ee' }, 'N')
+    )
+  );
+}
+
+export function ModernHeader() {
+  const [currentTime, setCurrentTime] = React.useState(new Date());
+  React.useEffect(() => {
+    const timer = setInterval(() => setCurrentTime(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return React.createElement(
+    'nav',
+    { style: { background: 'linear-gradient(135deg, #0a2463 0%, #1e3a5f 40%, #2e5266 70%, #3e7b69 100%)', minHeight: '60px', padding: '0 30px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', position: 'relative', zIndex: 1001, boxShadow: '0 2px 20px rgba(0,0,0,0.3)', borderBottom: '1px solid rgba(255,255,255,0.1)' } },
+    React.createElement(
+      'div',
+      { style: { display: 'flex', alignItems: 'center', gap: '15px' } },
+      React.createElement('img', { src: process.env.PUBLIC_URL + '/COSPPaC_white_crop2.png', alt: 'COSPPaC Logo', height: '35', style: { filter: 'brightness(0) saturate(100%) invert(100%)' } }),
+      React.createElement(
+        'div',
+        null,
+        React.createElement('h1', { style: { margin: 0, color: '#00d4ff', fontSize: '1.5rem', fontWeight: '700' } }, 'Cook Islands Wave and Innundation Forecast System'),
+        React.createElement('p', { style: { margin: 0, color: 'rgba(255,255,255,0.8)', fontSize: '0.9rem', fontWeight: '300' } }, 'Marine Forecasting • Pacific Community (SPC) Data')
+      )
+    ),
+    React.createElement('div', { style: { display: 'flex', alignItems: 'center', gap: '20px', fontSize: '0.8rem', color: 'rgba(255,255,255,0.7)' } }, `Live ${currentTime.toLocaleString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })}`)
+  );
+}
+
+export function LoadingSpinner({ size = 28, color = '#3b82f6', label = 'Loading...' }) {
+  return React.createElement(
+    'div',
+    { style: { display: 'inline-flex', alignItems: 'center', gap: '10px' } },
+    React.createElement('span', { style: { width: `${size}px`, height: `${size}px`, borderRadius: '50%', border: '3px solid rgba(148,163,184,0.35)', borderTopColor: color, animation: 'owp-spin 0.8s linear infinite', display: 'inline-block' } }),
+    React.createElement('span', null, label),
+    React.createElement('style', null, '@keyframes owp-spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }')
+  );
+}
+
+export function LoadingOverlay({ visible = false, label = 'Loading data...' }) {
+  if (!visible) return null;
+  return React.createElement(
+    'div',
+    { style: { position: 'absolute', inset: 0, background: 'rgba(15,23,42,0.35)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 20 } },
+    React.createElement('div', { style: { background: 'rgba(255,255,255,0.9)', padding: '12px 16px', borderRadius: '8px', color: '#0f172a' } }, React.createElement(LoadingSpinner, { label }))
+  );
+}
+
+export function PanelContainer({ title, children, footer, className = '', style = {} }) {
+  return React.createElement(
+    'section',
+    { className, style: { display: 'flex', flexDirection: 'column', borderRadius: '12px', overflow: 'hidden', ...style } },
+    title ? React.createElement('header', { style: { padding: '10px 14px', fontWeight: 600 } }, title) : null,
+    React.createElement('div', { style: { flex: 1 } }, children),
+    footer ? React.createElement('footer', { style: { padding: '10px 14px' } }, footer) : null
+  );
+}
+
+export function ProfessionalLegend({ range = '0,4', className = '', style = {} }) {
+  const url = `https://ocean-plotter.spc.int/legend?layer=wave_height&range=${range}&palette=viridis`;
+  return React.createElement('div', { className, style: { position: 'relative', borderRadius: '6px', overflow: 'hidden', background: '#fff', border: '1px solid #e2e8f0', ...style } },
+    React.createElement('img', { src: url, alt: 'Legend for wave height', style: { maxWidth: '100%', height: 'auto' } })
   );
 }

--- a/plugin/platform/dist/src/components/PlatformPlaceholder.js
+++ b/plugin/platform/dist/src/components/PlatformPlaceholder.js
@@ -1,14 +1,65 @@
 import React from 'react';
 
 let spinnerStylesInjected = false;
+let compassRoseStylesInjected = false;
 
 function ensureSpinnerStyles() {
-  if (spinnerStylesInjected || typeof document === 'undefined') return;
+  if (typeof document === 'undefined') return;
+  const existingTag = document.head && document.head.querySelector('style[data-owp-spinner="true"]');
+  if (existingTag) {
+    spinnerStylesInjected = true;
+    return;
+  }
+  if (spinnerStylesInjected) return;
   const styleTag = document.createElement('style');
   styleTag.setAttribute('data-owp-spinner', 'true');
   styleTag.textContent = '@keyframes owp-spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }';
   document.head.appendChild(styleTag);
   spinnerStylesInjected = true;
+}
+
+function ensureCompassRoseStyles() {
+  if (typeof document === 'undefined') return;
+  const existingTag = document.head && document.head.querySelector('style[data-owp-compass-rose="true"]');
+  if (existingTag) {
+    compassRoseStylesInjected = true;
+    return;
+  }
+  if (compassRoseStylesInjected) return;
+  const styleTag = document.createElement('style');
+  styleTag.setAttribute('data-owp-compass-rose', 'true');
+  styleTag.textContent = `
+    .owp-compass-rose-container {
+      animation: owp-compass-fade-in 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+      user-select: none;
+      -webkit-user-select: none;
+      -ms-user-select: none;
+      pointer-events: none;
+      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    .owp-compass-rose-svg {
+      transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), filter 0.2s ease-out;
+      backdrop-filter: blur(1px);
+      -webkit-backdrop-filter: blur(1px);
+      pointer-events: none;
+    }
+    .owp-compass-rose-container:hover .owp-compass-rose-svg {
+      filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.4));
+      transform: scale(1.03);
+    }
+    @keyframes owp-compass-fade-in {
+      from { opacity: 0; transform: scale(0.9) translateY(8px); }
+      to { opacity: 0.94; transform: scale(1) translateY(0); }
+    }
+    @media (max-width: 768px) {
+      .owp-compass-rose-container { transform: scale(0.85); transform-origin: bottom left; }
+    }
+    @media (max-width: 480px) {
+      .owp-compass-rose-container { transform: scale(0.75); transform-origin: bottom left; opacity: 0.88; }
+    }
+  `;
+  document.head.appendChild(styleTag);
+  compassRoseStylesInjected = true;
 }
 
 export function PlatformPlaceholder({ label = 'Ocean Widget Platform Ready' }) {
@@ -48,6 +99,10 @@ export function CompassRose({ position = 'bottom-left', size = 100, mapRotation 
   const [currentPosition, setCurrentPosition] = React.useState(position);
 
   React.useEffect(() => {
+    ensureCompassRoseStyles();
+  }, []);
+
+  React.useEffect(() => {
     if (!responsive || typeof window === 'undefined') return undefined;
     const handleResize = () => {
       const isMobile = window.innerWidth < 768;
@@ -69,10 +124,10 @@ export function CompassRose({ position = 'bottom-left', size = 100, mapRotation 
 
   return React.createElement(
     'div',
-    { style: { position: 'absolute', zIndex: 1000, pointerEvents: 'none', opacity: 0.94, ...positionStyles[currentPosition], width: `${size}px`, height: `${size}px` } },
+    { className: 'owp-compass-rose-container', style: { position: 'absolute', zIndex: 1000, pointerEvents: 'none', opacity: 0.94, ...positionStyles[currentPosition], width: `${size}px`, height: `${size}px` } },
     React.createElement(
       'svg',
-      { width: size, height: size, viewBox: '0 0 120 120', style: { transform: mapRotation ? `rotate(${-mapRotation}deg)` : 'none', filter: 'drop-shadow(0 6px 12px rgba(0,0,0,0.35))' } },
+      { className: 'owp-compass-rose-svg', width: size, height: size, viewBox: '0 0 120 120', style: { transform: mapRotation ? `rotate(${-mapRotation}deg)` : 'none', filter: 'drop-shadow(0 6px 12px rgba(0,0,0,0.35))' } },
       React.createElement('circle', { cx: '60', cy: '60', r: '55', fill: 'rgba(15,23,42,0.95)', stroke: 'rgba(148,163,184,0.4)', strokeWidth: '1.5' }),
       React.createElement('path', { d: 'M 60,12 L 65,45 L 60,40 L 55,45 Z', fill: '#22d3ee', stroke: '#0e7490', strokeWidth: '1.2' }),
       React.createElement('path', { d: 'M 108,60 L 75,65 L 80,60 L 75,55 Z', fill: '#94a3b8', stroke: '#475569', strokeWidth: '0.8' }),
@@ -91,7 +146,13 @@ function getDefaultLogoSrc() {
   return '/COSPPaC_white_crop2.png';
 }
 
-export function ModernHeader({ logoSrc = getDefaultLogoSrc() }) {
+export function ModernHeader({
+  logoSrc = getDefaultLogoSrc(),
+  title = 'Cook Islands Wave and Inundation Forecast System',
+  subtitle = 'Marine Forecasting • Pacific Community (SPC) Data',
+  statusText = 'Live',
+  showClock = true
+}) {
   const [currentTime, setCurrentTime] = React.useState(new Date());
   React.useEffect(() => {
     const timer = setInterval(() => setCurrentTime(new Date()), 1000);
@@ -108,11 +169,11 @@ export function ModernHeader({ logoSrc = getDefaultLogoSrc() }) {
       React.createElement(
         'div',
         null,
-        React.createElement('h1', { style: { margin: 0, color: '#00d4ff', fontSize: '1.5rem', fontWeight: '700' } }, 'Cook Islands Wave and Inundation Forecast System'),
-        React.createElement('p', { style: { margin: 0, color: 'rgba(255,255,255,0.8)', fontSize: '0.9rem', fontWeight: '300' } }, 'Marine Forecasting • Pacific Community (SPC) Data')
+        React.createElement('h1', { style: { margin: 0, color: '#00d4ff', fontSize: '1.5rem', fontWeight: '700' } }, title),
+        React.createElement('p', { style: { margin: 0, color: 'rgba(255,255,255,0.8)', fontSize: '0.9rem', fontWeight: '300' } }, subtitle)
       )
     ),
-    React.createElement('div', { style: { display: 'flex', alignItems: 'center', gap: '20px', fontSize: '0.8rem', color: 'rgba(255,255,255,0.7)' } }, `Live ${currentTime.toLocaleString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })}`)
+    React.createElement('div', { style: { display: 'flex', alignItems: 'center', gap: '20px', fontSize: '0.8rem', color: 'rgba(255,255,255,0.7)' } }, showClock ? `${statusText} ${currentTime.toLocaleString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })}` : statusText)
   );
 }
 
@@ -123,8 +184,8 @@ export function LoadingSpinner({ size = 28, color = '#3b82f6', label = 'Loading.
 
   return React.createElement(
     'div',
-    { style: { display: 'inline-flex', alignItems: 'center', gap: '10px' } },
-    React.createElement('span', { style: { width: `${size}px`, height: `${size}px`, borderRadius: '50%', border: '3px solid rgba(148,163,184,0.35)', borderTopColor: color, animation: 'owp-spin 0.8s linear infinite', display: 'inline-block' } }),
+    { style: { display: 'inline-flex', alignItems: 'center', gap: '10px' }, role: 'status', 'aria-live': 'polite', 'aria-busy': true },
+    React.createElement('span', { style: { width: `${size}px`, height: `${size}px`, borderRadius: '50%', border: '3px solid rgba(148,163,184,0.35)', borderTopColor: color, animation: 'owp-spin 0.8s linear infinite', display: 'inline-block' }, 'aria-hidden': true }),
     React.createElement('span', null, label)
   );
 }

--- a/plugin/platform/dist/src/components/PlatformPlaceholder.js
+++ b/plugin/platform/dist/src/components/PlatformPlaceholder.js
@@ -1,10 +1,21 @@
 import React from 'react';
 
+let spinnerStylesInjected = false;
+
+function ensureSpinnerStyles() {
+  if (spinnerStylesInjected || typeof document === 'undefined') return;
+  const styleTag = document.createElement('style');
+  styleTag.setAttribute('data-owp-spinner', 'true');
+  styleTag.textContent = '@keyframes owp-spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }';
+  document.head.appendChild(styleTag);
+  spinnerStylesInjected = true;
+}
+
 export function PlatformPlaceholder({ label = 'Ocean Widget Platform Ready' }) {
   return React.createElement('div', { 'data-testid': 'platform-placeholder', style: { display: 'none' } }, label);
 }
 
-export function ArrowSVG({ angle, isDarkMode, size = 22, compassDirection = '', ariaLabel }) {
+function ArrowSVGBase({ angle, isDarkMode, size = 22, compassDirection = '', ariaLabel }) {
   const fillColor = isDarkMode ? '#f1f5f9' : '#000';
   const strokeColor = isDarkMode ? '#64748b' : '#666';
 
@@ -25,6 +36,12 @@ export function ArrowSVG({ angle, isDarkMode, size = 22, compassDirection = '', 
       strokeWidth: '1'
     })
   );
+}
+
+const MemoizedArrowSVG = React.memo(ArrowSVGBase);
+
+export function ArrowSVG(props) {
+  return React.createElement(MemoizedArrowSVG, props);
 }
 
 export function CompassRose({ position = 'bottom-left', size = 100, mapRotation = 0, responsive = true }) {
@@ -67,7 +84,14 @@ export function CompassRose({ position = 'bottom-left', size = 100, mapRotation 
   );
 }
 
-export function ModernHeader() {
+function getDefaultLogoSrc() {
+  if (typeof process !== 'undefined' && process.env && typeof process.env.PUBLIC_URL === 'string') {
+    return `${process.env.PUBLIC_URL}/COSPPaC_white_crop2.png`;
+  }
+  return '/COSPPaC_white_crop2.png';
+}
+
+export function ModernHeader({ logoSrc = getDefaultLogoSrc() }) {
   const [currentTime, setCurrentTime] = React.useState(new Date());
   React.useEffect(() => {
     const timer = setInterval(() => setCurrentTime(new Date()), 1000);
@@ -80,11 +104,11 @@ export function ModernHeader() {
     React.createElement(
       'div',
       { style: { display: 'flex', alignItems: 'center', gap: '15px' } },
-      React.createElement('img', { src: process.env.PUBLIC_URL + '/COSPPaC_white_crop2.png', alt: 'COSPPaC Logo', height: '35', style: { filter: 'brightness(0) saturate(100%) invert(100%)' } }),
+      React.createElement('img', { src: logoSrc, alt: 'COSPPaC Logo', height: '35', style: { filter: 'brightness(0) saturate(100%) invert(100%)' } }),
       React.createElement(
         'div',
         null,
-        React.createElement('h1', { style: { margin: 0, color: '#00d4ff', fontSize: '1.5rem', fontWeight: '700' } }, 'Cook Islands Wave and Innundation Forecast System'),
+        React.createElement('h1', { style: { margin: 0, color: '#00d4ff', fontSize: '1.5rem', fontWeight: '700' } }, 'Cook Islands Wave and Inundation Forecast System'),
         React.createElement('p', { style: { margin: 0, color: 'rgba(255,255,255,0.8)', fontSize: '0.9rem', fontWeight: '300' } }, 'Marine Forecasting • Pacific Community (SPC) Data')
       )
     ),
@@ -93,12 +117,15 @@ export function ModernHeader() {
 }
 
 export function LoadingSpinner({ size = 28, color = '#3b82f6', label = 'Loading...' }) {
+  React.useEffect(() => {
+    ensureSpinnerStyles();
+  }, []);
+
   return React.createElement(
     'div',
     { style: { display: 'inline-flex', alignItems: 'center', gap: '10px' } },
     React.createElement('span', { style: { width: `${size}px`, height: `${size}px`, borderRadius: '50%', border: '3px solid rgba(148,163,184,0.35)', borderTopColor: color, animation: 'owp-spin 0.8s linear infinite', display: 'inline-block' } }),
-    React.createElement('span', null, label),
-    React.createElement('style', null, '@keyframes owp-spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }')
+    React.createElement('span', null, label)
   );
 }
 
@@ -121,8 +148,17 @@ export function PanelContainer({ title, children, footer, className = '', style 
   );
 }
 
-export function ProfessionalLegend({ range = '0,4', className = '', style = {} }) {
-  const url = `https://ocean-plotter.spc.int/legend?layer=wave_height&range=${range}&palette=viridis`;
+const DEFAULT_RANGE = '0,4';
+
+function sanitizeRange(range) {
+  const value = typeof range === 'string' ? range : String(range);
+  const rangePattern = /^[+-]?\d+(\.\d+)?,[+-]?\d+(\.\d+)?$/;
+  return rangePattern.test(value) ? value : DEFAULT_RANGE;
+}
+
+export function ProfessionalLegend({ range = DEFAULT_RANGE, className = '', style = {} }) {
+  const safeRange = sanitizeRange(range);
+  const url = `https://ocean-plotter.spc.int/legend?layer=wave_height&range=${encodeURIComponent(safeRange)}&palette=viridis`;
   return React.createElement('div', { className, style: { position: 'relative', borderRadius: '6px', overflow: 'hidden', background: '#fff', border: '1px solid #e2e8f0', ...style } },
     React.createElement('img', { src: url, alt: 'Legend for wave height', style: { maxWidth: '100%', height: 'auto' } })
   );

--- a/plugin/platform/dist/src/index.js
+++ b/plugin/platform/dist/src/index.js
@@ -1,1 +1,10 @@
-export { PlatformPlaceholder } from './components/PlatformPlaceholder.js';
+export {
+  PlatformPlaceholder,
+  ArrowSVG,
+  CompassRose,
+  ModernHeader,
+  ProfessionalLegend,
+  LoadingSpinner,
+  LoadingOverlay,
+  PanelContainer
+} from './components/PlatformPlaceholder.js';

--- a/plugin/platform/src/components/PlatformPlaceholder.js
+++ b/plugin/platform/src/components/PlatformPlaceholder.js
@@ -1,9 +1,129 @@
 import React from 'react';
 
 export function PlatformPlaceholder({ label = 'Ocean Widget Platform Ready' }) {
+  return React.createElement('div', { 'data-testid': 'platform-placeholder', style: { display: 'none' } }, label);
+}
+
+export function ArrowSVG({ angle, isDarkMode, size = 22, compassDirection = '', ariaLabel }) {
+  const fillColor = isDarkMode ? '#f1f5f9' : '#000';
+  const strokeColor = isDarkMode ? '#64748b' : '#666';
+
+  return React.createElement(
+    'svg',
+    {
+      width: size,
+      height: size,
+      viewBox: `0 0 ${size} ${size}`,
+      style: { display: 'inline-block', transform: `rotate(${angle}deg)`, filter: isDarkMode ? 'invert(1)' : 'none' },
+      role: 'img',
+      'aria-label': ariaLabel || `Direction: ${angle}° ${compassDirection}`
+    },
+    React.createElement('polygon', {
+      points: `${size / 2},2 ${size * 0.73},${size * 0.82} ${size / 2},${size * 0.64} ${size * 0.27},${size * 0.82}`,
+      fill: fillColor,
+      stroke: strokeColor,
+      strokeWidth: '1'
+    })
+  );
+}
+
+export function CompassRose({ position = 'bottom-left', size = 100, mapRotation = 0, responsive = true }) {
+  const [currentPosition, setCurrentPosition] = React.useState(position);
+
+  React.useEffect(() => {
+    if (!responsive || typeof window === 'undefined') return undefined;
+    const handleResize = () => {
+      const isMobile = window.innerWidth < 768;
+      setCurrentPosition(isMobile && position === 'top-right' ? 'bottom-left' : position);
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [position, responsive]);
+
+  const positionStyles = {
+    'top-left': { top: '15px', left: '15px' },
+    'top-right': { top: '15px', right: '15px' },
+    'bottom-left': { bottom: '120px', left: '15px' },
+    'bottom-right': { bottom: '80px', right: '15px' },
+    'center-left': { top: '50%', left: '15px', transform: 'translateY(-50%)' },
+    'map-center': { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }
+  };
+
   return React.createElement(
     'div',
-    { 'data-testid': 'platform-placeholder', style: { display: 'none' } },
-    label
+    { style: { position: 'absolute', zIndex: 1000, pointerEvents: 'none', opacity: 0.94, ...positionStyles[currentPosition], width: `${size}px`, height: `${size}px` } },
+    React.createElement(
+      'svg',
+      { width: size, height: size, viewBox: '0 0 120 120', style: { transform: mapRotation ? `rotate(${-mapRotation}deg)` : 'none', filter: 'drop-shadow(0 6px 12px rgba(0,0,0,0.35))' } },
+      React.createElement('circle', { cx: '60', cy: '60', r: '55', fill: 'rgba(15,23,42,0.95)', stroke: 'rgba(148,163,184,0.4)', strokeWidth: '1.5' }),
+      React.createElement('path', { d: 'M 60,12 L 65,45 L 60,40 L 55,45 Z', fill: '#22d3ee', stroke: '#0e7490', strokeWidth: '1.2' }),
+      React.createElement('path', { d: 'M 108,60 L 75,65 L 80,60 L 75,55 Z', fill: '#94a3b8', stroke: '#475569', strokeWidth: '0.8' }),
+      React.createElement('path', { d: 'M 60,108 L 55,75 L 60,80 L 65,75 Z', fill: '#94a3b8', stroke: '#475569', strokeWidth: '0.8' }),
+      React.createElement('path', { d: 'M 12,60 L 45,55 L 40,60 L 45,65 Z', fill: '#94a3b8', stroke: '#475569', strokeWidth: '0.8' }),
+      React.createElement('circle', { cx: '60', cy: '60', r: '4', fill: '#0891b2', stroke: '#22d3ee', strokeWidth: '1' }),
+      React.createElement('text', { x: '60', y: '8', textAnchor: 'middle', fontSize: '14', fontWeight: 'bold', fill: '#22d3ee' }, 'N')
+    )
+  );
+}
+
+export function ModernHeader() {
+  const [currentTime, setCurrentTime] = React.useState(new Date());
+  React.useEffect(() => {
+    const timer = setInterval(() => setCurrentTime(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return React.createElement(
+    'nav',
+    { style: { background: 'linear-gradient(135deg, #0a2463 0%, #1e3a5f 40%, #2e5266 70%, #3e7b69 100%)', minHeight: '60px', padding: '0 30px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', position: 'relative', zIndex: 1001, boxShadow: '0 2px 20px rgba(0,0,0,0.3)', borderBottom: '1px solid rgba(255,255,255,0.1)' } },
+    React.createElement(
+      'div',
+      { style: { display: 'flex', alignItems: 'center', gap: '15px' } },
+      React.createElement('img', { src: process.env.PUBLIC_URL + '/COSPPaC_white_crop2.png', alt: 'COSPPaC Logo', height: '35', style: { filter: 'brightness(0) saturate(100%) invert(100%)' } }),
+      React.createElement(
+        'div',
+        null,
+        React.createElement('h1', { style: { margin: 0, color: '#00d4ff', fontSize: '1.5rem', fontWeight: '700' } }, 'Cook Islands Wave and Innundation Forecast System'),
+        React.createElement('p', { style: { margin: 0, color: 'rgba(255,255,255,0.8)', fontSize: '0.9rem', fontWeight: '300' } }, 'Marine Forecasting • Pacific Community (SPC) Data')
+      )
+    ),
+    React.createElement('div', { style: { display: 'flex', alignItems: 'center', gap: '20px', fontSize: '0.8rem', color: 'rgba(255,255,255,0.7)' } }, `Live ${currentTime.toLocaleString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })}`)
+  );
+}
+
+export function LoadingSpinner({ size = 28, color = '#3b82f6', label = 'Loading...' }) {
+  return React.createElement(
+    'div',
+    { style: { display: 'inline-flex', alignItems: 'center', gap: '10px' } },
+    React.createElement('span', { style: { width: `${size}px`, height: `${size}px`, borderRadius: '50%', border: '3px solid rgba(148,163,184,0.35)', borderTopColor: color, animation: 'owp-spin 0.8s linear infinite', display: 'inline-block' } }),
+    React.createElement('span', null, label),
+    React.createElement('style', null, '@keyframes owp-spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }')
+  );
+}
+
+export function LoadingOverlay({ visible = false, label = 'Loading data...' }) {
+  if (!visible) return null;
+  return React.createElement(
+    'div',
+    { style: { position: 'absolute', inset: 0, background: 'rgba(15,23,42,0.35)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 20 } },
+    React.createElement('div', { style: { background: 'rgba(255,255,255,0.9)', padding: '12px 16px', borderRadius: '8px', color: '#0f172a' } }, React.createElement(LoadingSpinner, { label }))
+  );
+}
+
+export function PanelContainer({ title, children, footer, className = '', style = {} }) {
+  return React.createElement(
+    'section',
+    { className, style: { display: 'flex', flexDirection: 'column', borderRadius: '12px', overflow: 'hidden', ...style } },
+    title ? React.createElement('header', { style: { padding: '10px 14px', fontWeight: 600 } }, title) : null,
+    React.createElement('div', { style: { flex: 1 } }, children),
+    footer ? React.createElement('footer', { style: { padding: '10px 14px' } }, footer) : null
+  );
+}
+
+export function ProfessionalLegend({ range = '0,4', className = '', style = {} }) {
+  const url = `https://ocean-plotter.spc.int/legend?layer=wave_height&range=${range}&palette=viridis`;
+  return React.createElement('div', { className, style: { position: 'relative', borderRadius: '6px', overflow: 'hidden', background: '#fff', border: '1px solid #e2e8f0', ...style } },
+    React.createElement('img', { src: url, alt: 'Legend for wave height', style: { maxWidth: '100%', height: 'auto' } })
   );
 }

--- a/plugin/platform/src/components/PlatformPlaceholder.js
+++ b/plugin/platform/src/components/PlatformPlaceholder.js
@@ -1,14 +1,65 @@
 import React from 'react';
 
 let spinnerStylesInjected = false;
+let compassRoseStylesInjected = false;
 
 function ensureSpinnerStyles() {
-  if (spinnerStylesInjected || typeof document === 'undefined') return;
+  if (typeof document === 'undefined') return;
+  const existingTag = document.head && document.head.querySelector('style[data-owp-spinner="true"]');
+  if (existingTag) {
+    spinnerStylesInjected = true;
+    return;
+  }
+  if (spinnerStylesInjected) return;
   const styleTag = document.createElement('style');
   styleTag.setAttribute('data-owp-spinner', 'true');
   styleTag.textContent = '@keyframes owp-spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }';
   document.head.appendChild(styleTag);
   spinnerStylesInjected = true;
+}
+
+function ensureCompassRoseStyles() {
+  if (typeof document === 'undefined') return;
+  const existingTag = document.head && document.head.querySelector('style[data-owp-compass-rose="true"]');
+  if (existingTag) {
+    compassRoseStylesInjected = true;
+    return;
+  }
+  if (compassRoseStylesInjected) return;
+  const styleTag = document.createElement('style');
+  styleTag.setAttribute('data-owp-compass-rose', 'true');
+  styleTag.textContent = `
+    .owp-compass-rose-container {
+      animation: owp-compass-fade-in 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+      user-select: none;
+      -webkit-user-select: none;
+      -ms-user-select: none;
+      pointer-events: none;
+      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    .owp-compass-rose-svg {
+      transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), filter 0.2s ease-out;
+      backdrop-filter: blur(1px);
+      -webkit-backdrop-filter: blur(1px);
+      pointer-events: none;
+    }
+    .owp-compass-rose-container:hover .owp-compass-rose-svg {
+      filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.4));
+      transform: scale(1.03);
+    }
+    @keyframes owp-compass-fade-in {
+      from { opacity: 0; transform: scale(0.9) translateY(8px); }
+      to { opacity: 0.94; transform: scale(1) translateY(0); }
+    }
+    @media (max-width: 768px) {
+      .owp-compass-rose-container { transform: scale(0.85); transform-origin: bottom left; }
+    }
+    @media (max-width: 480px) {
+      .owp-compass-rose-container { transform: scale(0.75); transform-origin: bottom left; opacity: 0.88; }
+    }
+  `;
+  document.head.appendChild(styleTag);
+  compassRoseStylesInjected = true;
 }
 
 export function PlatformPlaceholder({ label = 'Ocean Widget Platform Ready' }) {
@@ -48,6 +99,10 @@ export function CompassRose({ position = 'bottom-left', size = 100, mapRotation 
   const [currentPosition, setCurrentPosition] = React.useState(position);
 
   React.useEffect(() => {
+    ensureCompassRoseStyles();
+  }, []);
+
+  React.useEffect(() => {
     if (!responsive || typeof window === 'undefined') return undefined;
     const handleResize = () => {
       const isMobile = window.innerWidth < 768;
@@ -69,10 +124,10 @@ export function CompassRose({ position = 'bottom-left', size = 100, mapRotation 
 
   return React.createElement(
     'div',
-    { style: { position: 'absolute', zIndex: 1000, pointerEvents: 'none', opacity: 0.94, ...positionStyles[currentPosition], width: `${size}px`, height: `${size}px` } },
+    { className: 'owp-compass-rose-container', style: { position: 'absolute', zIndex: 1000, pointerEvents: 'none', opacity: 0.94, ...positionStyles[currentPosition], width: `${size}px`, height: `${size}px` } },
     React.createElement(
       'svg',
-      { width: size, height: size, viewBox: '0 0 120 120', style: { transform: mapRotation ? `rotate(${-mapRotation}deg)` : 'none', filter: 'drop-shadow(0 6px 12px rgba(0,0,0,0.35))' } },
+      { className: 'owp-compass-rose-svg', width: size, height: size, viewBox: '0 0 120 120', style: { transform: mapRotation ? `rotate(${-mapRotation}deg)` : 'none', filter: 'drop-shadow(0 6px 12px rgba(0,0,0,0.35))' } },
       React.createElement('circle', { cx: '60', cy: '60', r: '55', fill: 'rgba(15,23,42,0.95)', stroke: 'rgba(148,163,184,0.4)', strokeWidth: '1.5' }),
       React.createElement('path', { d: 'M 60,12 L 65,45 L 60,40 L 55,45 Z', fill: '#22d3ee', stroke: '#0e7490', strokeWidth: '1.2' }),
       React.createElement('path', { d: 'M 108,60 L 75,65 L 80,60 L 75,55 Z', fill: '#94a3b8', stroke: '#475569', strokeWidth: '0.8' }),
@@ -91,7 +146,13 @@ function getDefaultLogoSrc() {
   return '/COSPPaC_white_crop2.png';
 }
 
-export function ModernHeader({ logoSrc = getDefaultLogoSrc() }) {
+export function ModernHeader({
+  logoSrc = getDefaultLogoSrc(),
+  title = 'Cook Islands Wave and Inundation Forecast System',
+  subtitle = 'Marine Forecasting • Pacific Community (SPC) Data',
+  statusText = 'Live',
+  showClock = true
+}) {
   const [currentTime, setCurrentTime] = React.useState(new Date());
   React.useEffect(() => {
     const timer = setInterval(() => setCurrentTime(new Date()), 1000);
@@ -108,11 +169,11 @@ export function ModernHeader({ logoSrc = getDefaultLogoSrc() }) {
       React.createElement(
         'div',
         null,
-        React.createElement('h1', { style: { margin: 0, color: '#00d4ff', fontSize: '1.5rem', fontWeight: '700' } }, 'Cook Islands Wave and Inundation Forecast System'),
-        React.createElement('p', { style: { margin: 0, color: 'rgba(255,255,255,0.8)', fontSize: '0.9rem', fontWeight: '300' } }, 'Marine Forecasting • Pacific Community (SPC) Data')
+        React.createElement('h1', { style: { margin: 0, color: '#00d4ff', fontSize: '1.5rem', fontWeight: '700' } }, title),
+        React.createElement('p', { style: { margin: 0, color: 'rgba(255,255,255,0.8)', fontSize: '0.9rem', fontWeight: '300' } }, subtitle)
       )
     ),
-    React.createElement('div', { style: { display: 'flex', alignItems: 'center', gap: '20px', fontSize: '0.8rem', color: 'rgba(255,255,255,0.7)' } }, `Live ${currentTime.toLocaleString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })}`)
+    React.createElement('div', { style: { display: 'flex', alignItems: 'center', gap: '20px', fontSize: '0.8rem', color: 'rgba(255,255,255,0.7)' } }, showClock ? `${statusText} ${currentTime.toLocaleString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })}` : statusText)
   );
 }
 
@@ -123,8 +184,8 @@ export function LoadingSpinner({ size = 28, color = '#3b82f6', label = 'Loading.
 
   return React.createElement(
     'div',
-    { style: { display: 'inline-flex', alignItems: 'center', gap: '10px' } },
-    React.createElement('span', { style: { width: `${size}px`, height: `${size}px`, borderRadius: '50%', border: '3px solid rgba(148,163,184,0.35)', borderTopColor: color, animation: 'owp-spin 0.8s linear infinite', display: 'inline-block' } }),
+    { style: { display: 'inline-flex', alignItems: 'center', gap: '10px' }, role: 'status', 'aria-live': 'polite', 'aria-busy': true },
+    React.createElement('span', { style: { width: `${size}px`, height: `${size}px`, borderRadius: '50%', border: '3px solid rgba(148,163,184,0.35)', borderTopColor: color, animation: 'owp-spin 0.8s linear infinite', display: 'inline-block' }, 'aria-hidden': true }),
     React.createElement('span', null, label)
   );
 }

--- a/plugin/platform/src/components/PlatformPlaceholder.js
+++ b/plugin/platform/src/components/PlatformPlaceholder.js
@@ -1,10 +1,21 @@
 import React from 'react';
 
+let spinnerStylesInjected = false;
+
+function ensureSpinnerStyles() {
+  if (spinnerStylesInjected || typeof document === 'undefined') return;
+  const styleTag = document.createElement('style');
+  styleTag.setAttribute('data-owp-spinner', 'true');
+  styleTag.textContent = '@keyframes owp-spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }';
+  document.head.appendChild(styleTag);
+  spinnerStylesInjected = true;
+}
+
 export function PlatformPlaceholder({ label = 'Ocean Widget Platform Ready' }) {
   return React.createElement('div', { 'data-testid': 'platform-placeholder', style: { display: 'none' } }, label);
 }
 
-export function ArrowSVG({ angle, isDarkMode, size = 22, compassDirection = '', ariaLabel }) {
+function ArrowSVGBase({ angle, isDarkMode, size = 22, compassDirection = '', ariaLabel }) {
   const fillColor = isDarkMode ? '#f1f5f9' : '#000';
   const strokeColor = isDarkMode ? '#64748b' : '#666';
 
@@ -25,6 +36,12 @@ export function ArrowSVG({ angle, isDarkMode, size = 22, compassDirection = '', 
       strokeWidth: '1'
     })
   );
+}
+
+const MemoizedArrowSVG = React.memo(ArrowSVGBase);
+
+export function ArrowSVG(props) {
+  return React.createElement(MemoizedArrowSVG, props);
 }
 
 export function CompassRose({ position = 'bottom-left', size = 100, mapRotation = 0, responsive = true }) {
@@ -67,7 +84,14 @@ export function CompassRose({ position = 'bottom-left', size = 100, mapRotation 
   );
 }
 
-export function ModernHeader() {
+function getDefaultLogoSrc() {
+  if (typeof process !== 'undefined' && process.env && typeof process.env.PUBLIC_URL === 'string') {
+    return `${process.env.PUBLIC_URL}/COSPPaC_white_crop2.png`;
+  }
+  return '/COSPPaC_white_crop2.png';
+}
+
+export function ModernHeader({ logoSrc = getDefaultLogoSrc() }) {
   const [currentTime, setCurrentTime] = React.useState(new Date());
   React.useEffect(() => {
     const timer = setInterval(() => setCurrentTime(new Date()), 1000);
@@ -80,11 +104,11 @@ export function ModernHeader() {
     React.createElement(
       'div',
       { style: { display: 'flex', alignItems: 'center', gap: '15px' } },
-      React.createElement('img', { src: process.env.PUBLIC_URL + '/COSPPaC_white_crop2.png', alt: 'COSPPaC Logo', height: '35', style: { filter: 'brightness(0) saturate(100%) invert(100%)' } }),
+      React.createElement('img', { src: logoSrc, alt: 'COSPPaC Logo', height: '35', style: { filter: 'brightness(0) saturate(100%) invert(100%)' } }),
       React.createElement(
         'div',
         null,
-        React.createElement('h1', { style: { margin: 0, color: '#00d4ff', fontSize: '1.5rem', fontWeight: '700' } }, 'Cook Islands Wave and Innundation Forecast System'),
+        React.createElement('h1', { style: { margin: 0, color: '#00d4ff', fontSize: '1.5rem', fontWeight: '700' } }, 'Cook Islands Wave and Inundation Forecast System'),
         React.createElement('p', { style: { margin: 0, color: 'rgba(255,255,255,0.8)', fontSize: '0.9rem', fontWeight: '300' } }, 'Marine Forecasting • Pacific Community (SPC) Data')
       )
     ),
@@ -93,12 +117,15 @@ export function ModernHeader() {
 }
 
 export function LoadingSpinner({ size = 28, color = '#3b82f6', label = 'Loading...' }) {
+  React.useEffect(() => {
+    ensureSpinnerStyles();
+  }, []);
+
   return React.createElement(
     'div',
     { style: { display: 'inline-flex', alignItems: 'center', gap: '10px' } },
     React.createElement('span', { style: { width: `${size}px`, height: `${size}px`, borderRadius: '50%', border: '3px solid rgba(148,163,184,0.35)', borderTopColor: color, animation: 'owp-spin 0.8s linear infinite', display: 'inline-block' } }),
-    React.createElement('span', null, label),
-    React.createElement('style', null, '@keyframes owp-spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }')
+    React.createElement('span', null, label)
   );
 }
 
@@ -121,8 +148,17 @@ export function PanelContainer({ title, children, footer, className = '', style 
   );
 }
 
-export function ProfessionalLegend({ range = '0,4', className = '', style = {} }) {
-  const url = `https://ocean-plotter.spc.int/legend?layer=wave_height&range=${range}&palette=viridis`;
+const DEFAULT_RANGE = '0,4';
+
+function sanitizeRange(range) {
+  const value = typeof range === 'string' ? range : String(range);
+  const rangePattern = /^[+-]?\d+(\.\d+)?,[+-]?\d+(\.\d+)?$/;
+  return rangePattern.test(value) ? value : DEFAULT_RANGE;
+}
+
+export function ProfessionalLegend({ range = DEFAULT_RANGE, className = '', style = {} }) {
+  const safeRange = sanitizeRange(range);
+  const url = `https://ocean-plotter.spc.int/legend?layer=wave_height&range=${encodeURIComponent(safeRange)}&palette=viridis`;
   return React.createElement('div', { className, style: { position: 'relative', borderRadius: '6px', overflow: 'hidden', background: '#fff', border: '1px solid #e2e8f0', ...style } },
     React.createElement('img', { src: url, alt: 'Legend for wave height', style: { maxWidth: '100%', height: 'auto' } })
   );

--- a/plugin/platform/src/index.js
+++ b/plugin/platform/src/index.js
@@ -1,1 +1,10 @@
-export { PlatformPlaceholder } from './components/PlatformPlaceholder.js';
+export {
+  PlatformPlaceholder,
+  ArrowSVG,
+  CompassRose,
+  ModernHeader,
+  ProfessionalLegend,
+  LoadingSpinner,
+  LoadingOverlay,
+  PanelContainer
+} from './components/PlatformPlaceholder.js';

--- a/plugin/widget5/package-lock.json
+++ b/plugin/widget5/package-lock.json
@@ -20,6 +20,7 @@
         "jquery": "^3.7.1",
         "leaflet": "^1.9.4",
         "lucide-react": "^0.544.0",
+        "ocean-widget-platform": "file:../platform",
         "plotly.js": "^3.1.0",
         "react": "^19.1.1",
         "react-bootstrap": "^2.10.10",
@@ -30,8 +31,7 @@
         "react-plotly.js": "^2.6.0",
         "react-router-dom": "^6.28.0",
         "react-scripts": "5.0.1",
-        "web-vitals": "^2.1.4",
-        "ocean-widget-platform": "file:../platform"
+        "web-vitals": "^2.1.4"
       },
       "devDependencies": {
         "concurrently": "^9.2.1",
@@ -39,6 +39,14 @@
         "express": "^5.1.0",
         "http-proxy-middleware": "^3.0.5",
         "jest": "^27.5.1"
+      }
+    },
+    "../platform": {
+      "name": "ocean-widget-platform",
+      "version": "0.1.0",
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -13182,6 +13190,10 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
+    "node_modules/ocean-widget-platform": {
+      "resolved": "../platform",
+      "link": true
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -19608,13 +19620,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "../platform": {
-      "version": "0.1.0"
-    },
-    "node_modules/ocean-widget-platform": {
-      "resolved": "../platform",
-      "link": true
     }
   }
 }

--- a/plugin/widget5/src/components/ForecastApp.jsx
+++ b/plugin/widget5/src/components/ForecastApp.jsx
@@ -5,7 +5,7 @@ import useMapInteraction from '../hooks/useMapInteraction';
 import { UI_CONFIG } from '../config/UIConfig';
 import { MARINE_CONFIG } from '../config/marineVariables';
 import { getLayerBounds } from '../config/layerConfig';
-import CompassRose from './CompassRose';
+import { CompassRose } from 'ocean-widget-platform';
 import { 
   ControlGroup, 
   VariableButtons, 

--- a/plugin/widget5/src/components/TableCell.jsx
+++ b/plugin/widget5/src/components/TableCell.jsx
@@ -2,7 +2,7 @@
  * Enhanced Table Cell Component with Accessibility and Performance Optimizations
  */
 import React, { useMemo } from 'react';
-import ArrowSVG from './ArrowSVG.jsx';
+import { ArrowSVG } from 'ocean-widget-platform';
 import { getColorFunction, isColorDark } from '../utils/colorSchemes.js';
 import { formatSmart } from '../utils/marineDataUtils.js';
 

--- a/plugin/widget5/src/pages/BottomBuoyOffCanvas.jsx
+++ b/plugin/widget5/src/pages/BottomBuoyOffCanvas.jsx
@@ -3,6 +3,7 @@ import Offcanvas from "react-bootstrap/Offcanvas";
 import 'chart.js/auto';
 import Plot from 'react-plotly.js';
 import './BottomBuoyOffCanvas.css';
+import { LoadingSpinner } from 'ocean-widget-platform';
 
 // Fixed color palette for datasets
 const BUOY_COLORS = [
@@ -761,7 +762,11 @@ function BottomBuoyOffCanvas({ show, onHide, buoyId }) {
         </button>
       </div>
       <Offcanvas.Body style={{ paddingTop: 16, height: 'calc(100% - 60px)' }}>
-        {activeTab === "buoy" && loading && <div style={{ textAlign: "center", padding: "2rem" }}>Loading buoy data...</div>}
+        {activeTab === "buoy" && loading && (
+          <div style={{ textAlign: "center", padding: "2rem" }}>
+            <LoadingSpinner label="Loading buoy data..." />
+          </div>
+        )}
         {activeTab === "buoy" && fetchError && <div style={{ color: "red", textAlign: "center" }}>{fetchError}</div>}
         {activeTab === "buoy" && !loading && !fetchError && data?.waves?.length > 0 && (
           <div style={{ width: "100%", height: "100%", minHeight: '300px' }}>
@@ -790,7 +795,9 @@ function BottomBuoyOffCanvas({ show, onHide, buoyId }) {
           <div style={{ textAlign: "center", color: "#999" }}>No data available for this buoy.</div>
         )}
         {activeTab === "model" && modelLoading && (
-          <div style={{ textAlign: "center", padding: "2rem" }}>Loading model data...</div>
+          <div style={{ textAlign: "center", padding: "2rem" }}>
+            <LoadingSpinner label="Loading model data..." />
+          </div>
         )}
         {activeTab === "model" && modelError && (
           <div style={{ color: "red", textAlign: "center" }}>{modelError}</div>

--- a/plugin/widget5/src/pages/BottomOffCanvas.jsx
+++ b/plugin/widget5/src/pages/BottomOffCanvas.jsx
@@ -3,6 +3,7 @@ import Offcanvas from "react-bootstrap/Offcanvas";
 import "./BottomOffCanvas.css";
 import Tabular from "./tabular.js";
 import Timeseries from "./timeseries.js";
+import { LoadingSpinner } from 'ocean-widget-platform';
 
 
 // ---- Variables & config for Cook Islands (adapted from Widget 1) ----
@@ -354,7 +355,7 @@ function BottomOffCanvas({ show, onHide, data }) {
       </div>
       <Offcanvas.Body style={{ paddingTop: 16 }}>
         {loading
-          ? <div style={{ textAlign: "center", padding: "2rem" }}>Loading data...</div>
+          ? <div style={{ textAlign: "center", padding: "2rem" }}><LoadingSpinner label="Loading data..." /></div>
           : fetchError
               ? <div style={{ color: "red", textAlign: "center" }}>{fetchError}</div>
               : <>

--- a/plugin/widget5/src/pages/Home.jsx
+++ b/plugin/widget5/src/pages/Home.jsx
@@ -6,7 +6,7 @@ import BottomOffCanvas from "./BottomOffCanvas";
 import BottomBuoyOffCanvas from "./BottomBuoyOffCanvas";
 import { useForecast } from "../hooks/useForecast";
 import ForecastApp from "../components/ForecastApp";
-import ModernHeader from "../components/ModernHeader";
+import { ModernHeader } from 'ocean-widget-platform';
 import WorldClassVisualization from "../utils/WorldClassVisualization";
 import LegendCleanup from "../components/LegendCleanup";
 


### PR DESCRIPTION
### Motivation

- Consolidate commonly used UI pieces into a single platform package so widgets can import a maintained, shared implementation instead of duplicating code. 
- Make loading, header, legend and small UI primitives available across widgets to reduce drift and visual regressions. 

### Description

- Added exports to the platform package for `ArrowSVG`, `CompassRose`, `ModernHeader`, `ProfessionalLegend`, `LoadingSpinner`, `LoadingOverlay`, and `PanelContainer` by updating `plugin/platform/src/components/PlatformPlaceholder.js` and `plugin/platform/src/index.js`, and rebuilt `dist` artifacts via the platform build script. 
- Updated Widget5 to consume the shared components from the platform package by replacing local imports with `ocean-widget-platform` in `plugin/widget5/src/components/TableCell.jsx`, `plugin/widget5/src/components/ForecastApp.jsx`, and `plugin/widget5/src/pages/Home.jsx`, and replaced inline loading text with the platform `LoadingSpinner` in `plugin/widget5/src/pages/BottomOffCanvas.jsx` and `plugin/widget5/src/pages/BottomBuoyOffCanvas.jsx`. 
- Updated local dependency wiring and lockfile so `widget5` points to the local `file:../platform` package (`plugin/widget5/package-lock.json`) and regenerated platform `dist` artifacts to expose the new named exports. 

### Testing

- Ran `npm --prefix plugin/platform run build` and the platform build succeeded (dist artifacts updated). 
- Ran `npm --prefix plugin/widget5 install` to refresh dependency links and then attempted `npm --prefix plugin/widget5 run build`, which failed due to pre-existing ESLint errors in `plugin/widget5/src/App.jsx` for unused variables (`widgetData` and `validCountries`) that are unrelated to the extraction; the failures block a clean widget build in this environment. 
- Verified that source files were updated to import the platform exports and that the platform build artifacts export the new components (manual inspection and build logs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb672c4d908323876cf4ba8ffc296f)